### PR TITLE
Votekick failed fix and added remaining() variable

### DIFF
--- a/src/main/java/fr/zetamap/morecommands/modules/voting/VoteKickSession.java
+++ b/src/main/java/fr/zetamap/morecommands/modules/voting/VoteKickSession.java
@@ -162,7 +162,7 @@ public class VoteKickSession extends PlayerVoteSession<VoteKickSession.Context> 
       @ [lightgray]voted to @[lightgray]kick @[lightgray].
       @ more @ required [gray]([lightgray]@[gray]/[lightgray]@[gray])[white]. \
       Type [orange]/vote y[] or [orange]/vote n[] to agree or not with him.""",
-      who.getName(), type.yes() ? "[]" : "[]not ", objective().target.getName(), "[]"+vote, "[]"+votes(),
+      who.getName(), type.yes() ? "[]" : "[]not ", objective().target.getName(), remaining(), "[]"+vote, "[]"+votes(),
       "[]"+required()
     );
   }

--- a/src/main/java/fr/zetamap/morecommands/modules/voting/VoteSession.java
+++ b/src/main/java/fr/zetamap/morecommands/modules/voting/VoteSession.java
@@ -80,7 +80,7 @@ public abstract class VoteSession<P, O> {
 
   /** @return whether the current vote session can be stopped. */
   public boolean canStop() {
-    return started();
+    return task != null;
   }
 
   /**

--- a/src/main/java/fr/zetamap/morecommands/modules/voting/VotingModule.java
+++ b/src/main/java/fr/zetamap/morecommands/modules/voting/VotingModule.java
@@ -71,7 +71,7 @@ public class VotingModule extends AbstractModule {
     // Players who are currently being voted on can no longer interact, to prevent griefing.
     Vars.netServer.admins.addActionFilter(a -> {
       return getrate(a.player).get(messageRateLimit, () -> {
-        if (vkSession.started() && vkSession.objective().target.player == a.player) {
+        if (vkSession.started() && vkSession.objective() != null && vkSession.objective().target.player == a.player) {
           Players.err(a.player, "You are currently being voted in. \n"
                               + "You can no longer interact with the game elements until the vote ends.");
           return false;


### PR DESCRIPTION
Before votekicks were not failing, which allowed one player to vote twice or more (same with /rtv)
Added remaining() variable

<img width="509" height="316" alt="image" src="https://github.com/user-attachments/assets/51a8ac27-46d7-45c9-9303-47ffdebc246b" />


Before: 
<img width="515" height="325" alt="image" src="https://github.com/user-attachments/assets/10aa008b-286c-4540-9a8b-28e999836e00" />
